### PR TITLE
#20573 Document OpenTelemetry setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ While the default configurations are suitable for a quick start and testing purp
 Though not exhaustive, the included [air-gap](./helm-airgap/README.md) and [OpenShift](./helm-openshift/) examples will demonstrate how some more complex configurations can be achieved. 
 
 
+### Observability
+
+The Howso Platform can publish metrics and traces using the [OpenTelemetry](https://opentelemetry.io) system.  This depends on a collector being installed in the cluster.  There is a [basic OpenTelemetry sample setup](opentelemetry/README.md) that installs the collector and configures the Howso Platform to send it data.  An [extended end-to-end OpenTelemetry sample setup](opentelemetry-e2e/README.md) installs additional open-source observability tools to examine and monitor the system state.
+
+
 ### Securing Howso Platform
 
 Securing the Howso Platform is discussed in the [security](security/README.md) section.  This includes the use of Service Mesh, Network Policies, and other security topics. 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Though not exhaustive, the included [air-gap](./helm-airgap/README.md) and [Open
 
 ### Observability
 
-The Howso Platform can publish metrics and traces using the [OpenTelemetry](https://opentelemetry.io) system.  This depends on a collector being installed in the cluster.  There is a [basic OpenTelemetry sample setup](opentelemetry/README.md) that installs the collector and configures the Howso Platform to send it data.  An [extended end-to-end OpenTelemetry sample setup](opentelemetry-e2e/README.md) installs additional open-source observability tools to examine and monitor the system state.
+The Howso Platform can publish metrics and traces using the [OpenTelemetry](https://opentelemetry.io) system beginning with release 2024.6.1.  This depends on a collector being installed in the cluster.  There is a [basic OpenTelemetry sample setup](opentelemetry/README.md) that installs the collector and configures the Howso Platform to send it data.  An [extended end-to-end OpenTelemetry sample setup](opentelemetry-e2e/README.md) installs additional open-source observability tools to examine and monitor the system state.
 
 
 ### Securing Howso Platform

--- a/opentelemetry-e2e/README.md
+++ b/opentelemetry-e2e/README.md
@@ -1,0 +1,65 @@
+# OpenTelemetry End-to-End Setup
+
+This example builds on the general [OpenTelemetry setup](../opentelemetry/README.md) with an end-to-end installation.  The previous example installed the OpenTelemetry collector, and configured the Howso Platform to talk to it.  This example additionally installs
+
+- [Prometheus](https://prometheus.io/), to collect metrics;
+- [Grafana](https://grafana.com/), to display metrics on dashboards; and
+- [Jaeger](https://jaegertracing.io/), to collect and display distributed traces
+
+and then configures the OpenTelemetry collector to publish to these components.
+
+## Kube-Prometheus Stack
+
+The [Kube-Prometheus Stack](https://github.com/prometheus-operator/kube-prometheus) is a prepackaged metric-management system for Kubernetes.  It includes both Prometheus and Grafana, a set of prebuilt Grafana dashboards, and a Kubernetes operator to manage these tools via in-cluster configuration.  The stack can be installed via a [Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) which we will use for consistency with our other tools.
+
+There are two options that need to be configured.  The Helm chart includes Kubernetes Ingress resources that allow external callers to reach Prometheus and Grafana, and we need to configure their host names.  We also need to enable an endpoint in Prometheus to allow the OpenTelemetry collector to push metrics to it.  These settings are included in the [sample Helm values](manifests/kube-prometheus-stack.yaml).
+
+```sh
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  --namespace howso \
+  --values opentelemetry-e2e/manifests/kube-prometheus-stack.yaml
+```
+
+## Jaeger
+
+Jaeger can also be installed via a [Helm chart](https://github.com/jaegertracing/helm-charts).
+
+The default Jaeger configuration is a heavy-weight production-oriented installation, including a Cassandra instance as the primary data store.  The [sample Helm values](manifests/jaeger.yaml) here use a much smaller "all-in-one" configuration, with only a single Kubernetes Pod running the entire system.  Note that the configuration here does not persist data outside of the Pod-local filesystem.
+
+```sh
+helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+helm repo update
+helm install jaeger jaegertracing/jaeger \
+  --namespace howso \
+  --values opentelemetry-e2e/manifests/jaeger.yaml
+```
+
+## OpenTelemetry Collector
+
+In the previous example we only minimally configured the OpenTelemetry collector.  We now have destinations for both metrics and traces and we can include those in the collector configuration.  In the [sample extended Helm values](manifests/opentelemetry-collector.yaml) we configure sending metrics to Prometheus's push gateway, and traces to Jaeger using gRPC without TLS.  This configuration also disables the collector endpoints other than the OpenTelemetry OTLP endpoints.
+
+```sh
+helm upgrade --install platform-opentelemetry-collector \
+  open-telemetry/opentelemetry-collector \
+  --namespace howso \
+  --values opentelemetry/manifests/opentelemetry-collector.yaml \
+  --values opentelemetry-e2e/manifests/opentelemetry-collector.yaml
+```
+
+## Accessing the Observability UIs
+
+The configurations here create Kubernetes Ingress resources for the various components.  In the [prerequisites](../prereqs/README.md#setup-hosts), we added entries to the local hosts file to be able to access the Howso Platform.  Additionally include in the hosts file
+
+```none
+127.0.0.1 grafana.local.howso.com
+127.0.0.1 jaeger.local.howso.com
+127.0.0.1 prometheus.local.howso.com
+```
+
+[Jaeger](http://jaeger.local.howso.com) shows distributed traces.  As you make requests using the Howso client library, it collects records that show how requests pass through the system and some details of what happens inside each request.  Traces have more detailed information, but are also expensive to collect.  A typical tracing configuration will drop a significant fraction of traces, maybe only keeping error traces plus 1% of non-error traces.
+
+[Prometheus](http://prometheus.local.howso.com) collects metrics.  Metrics are almost always aggregated, so you cannot see individual requests' data, but you can see the overall state of the system over time.  The Howso Platform emits relatively few metrics but you can browse for example `http_server_duration_milliseconds_count` to see the number of HTTP requests that each component of the system receives.
+
+[Grafana](http://grafana.local.howso.com) (`admin`/`prom-operator` default login) displays metrics on dashboards.  The Howso Platform does not include any custom dashboards, but the Kube-Prometheus stack does install some Kubernetes-related dashboards.  You can use the "Explore" tab to construct queries against the Prometheus backend.

--- a/opentelemetry-e2e/README.md
+++ b/opentelemetry-e2e/README.md
@@ -12,7 +12,9 @@ and then configures the OpenTelemetry collector to publish to these components.
 
 The [Kube-Prometheus Stack](https://github.com/prometheus-operator/kube-prometheus) is a prepackaged metric-management system for Kubernetes.  It includes both Prometheus and Grafana, a set of prebuilt Grafana dashboards, and a Kubernetes operator to manage these tools via in-cluster configuration.  The stack can be installed via a [Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) which we will use for consistency with our other tools.
 
-There are two options that need to be configured.  The Helm chart includes Kubernetes Ingress resources that allow external callers to reach Prometheus and Grafana, and we need to configure their host names.  We also need to enable an endpoint in Prometheus to allow the OpenTelemetry collector to push metrics to it.  These settings are included in the [sample Helm values](manifests/kube-prometheus-stack.yaml).
+This setup is designed as an integrated end-to-end monitoring system, including the ability to deploy Prometheus itself.  The embedded operator requires [significant cluster-level permissions](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus-operator/clusterrole.yaml), including global unrestricted permissions over StatefulSets, ConfigMaps, and Secrets.  The Howso Platform only directly communicates with the OpenTelemetry collector, which can also work with other Prometheus installations requiring less permissions.
+
+There are two options that need to be configured in Kube-Prometheus Stack.  The Helm chart includes Kubernetes Ingress resources that allow external callers to reach Prometheus and Grafana, and we need to configure their host names.  We also need to enable an endpoint in Prometheus to allow the OpenTelemetry collector to push metrics to it.  These settings are included in the [sample Helm values](manifests/kube-prometheus-stack.yaml).
 
 ```sh
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts

--- a/opentelemetry-e2e/README.md
+++ b/opentelemetry-e2e/README.md
@@ -21,7 +21,8 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --namespace howso \
-  --values opentelemetry-e2e/manifests/kube-prometheus-stack.yaml
+  --values opentelemetry-e2e/manifests/kube-prometheus-stack.yaml \
+  --wait
 ```
 
 ## Jaeger
@@ -35,7 +36,8 @@ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 helm repo update
 helm install jaeger jaegertracing/jaeger \
   --namespace howso \
-  --values opentelemetry-e2e/manifests/jaeger.yaml
+  --values opentelemetry-e2e/manifests/jaeger.yaml \
+  --wait
 ```
 
 ## OpenTelemetry Collector
@@ -47,7 +49,8 @@ helm upgrade --install platform-opentelemetry-collector \
   open-telemetry/opentelemetry-collector \
   --namespace howso \
   --values opentelemetry/manifests/opentelemetry-collector.yaml \
-  --values opentelemetry-e2e/manifests/opentelemetry-collector.yaml
+  --values opentelemetry-e2e/manifests/opentelemetry-collector.yaml \
+  --wait
 ```
 
 ## Accessing the Observability UIs

--- a/opentelemetry-e2e/manifests/jaeger.yaml
+++ b/opentelemetry-e2e/manifests/jaeger.yaml
@@ -1,0 +1,17 @@
+allInOne:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - jaeger.local.howso.com
+storage: 
+  type: badger
+
+agent:
+  enabled: false
+collector:
+  enabled: false
+provisionDataStore:
+  cassandra: false
+query:
+  enabled: false

--- a/opentelemetry-e2e/manifests/kube-prometheus-stack.yaml
+++ b/opentelemetry-e2e/manifests/kube-prometheus-stack.yaml
@@ -1,0 +1,14 @@
+grafana:
+  ingress:
+    enabled: true
+    hosts:
+    - grafana.local.howso.com
+prometheus:
+  ingress:
+    enabled: true
+    hosts:
+    - prometheus.local.howso.com
+    paths:
+    - /
+  prometheusSpec:
+    enableRemoteWriteReceiver: true

--- a/opentelemetry-e2e/manifests/opentelemetry-collector.yaml
+++ b/opentelemetry-e2e/manifests/opentelemetry-collector.yaml
@@ -1,0 +1,24 @@
+config:
+  exporters:
+    otlp/jaeger:
+      endpoint: jaeger-collector:4317
+      tls:
+        insecure: true
+    prometheusremotewrite:
+      endpoint: http://kube-prometheus-stack-prometheus:9090/api/v1/write
+  receivers:
+    jaeger: null
+    prometheus: null
+    zipkin: null
+  service:
+    pipelines:
+      metrics:
+        exporters:
+        - prometheusremotewrite
+        receivers:
+        - otlp
+      traces:
+        exporters:
+        - otlp/jaeger
+        receivers:
+        - otlp

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -11,7 +11,7 @@
 
 To process telemetry data, the Howso Platform requires that the cluster be running an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).  Individual components of the system forward data to the collector, which in turn forwards it onwards to other observability tools.  An OpenTelemetry collector might forward traces to a [Jaeger](https://www.jaegertracing.io/) instance and metrics to [Prometheus](https://prometheus.io), for example.  So long as the collector is running, the Howso Platform is agnostic to the specific choice of observability backends.
 
-The Howso Platform does not require an OpenTelemetry collector for standard data processing and synthesis tasks.  It is only required to collect more detailed metrics about individual components' operation and to debug performance and scaling problems in the system.
+The Howso Platform does not require an OpenTelemetry collector for standard data processing and synthesis tasks.  It is only required to collect more detailed metrics about individual components' operations and to debug performance and scaling problems in the system.
 
 ## Installing the Collector
 
@@ -22,7 +22,8 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install platform-opentelemetry-collector \
   open-telemetry/opentelemetry-collector \
   --namespace howso \
-  --values opentelemetry/manifests/opentelemetry-collector.yaml
+  --values opentelemetry/manifests/opentelemetry-collector.yaml \
+  --wait
 ```
 
 This default configuration installs a collector, but does not necessarily send its output anywhere.  The chart can take [extended configuration options](https://opentelemetry.io/docs/kubernetes/helm/collector/#configuration) that tell it where to forward traces and metrics when it receives them.
@@ -34,10 +35,11 @@ The sample configuration uses the Kubernetes API to collect Kubernetes-related a
 The Howso Platform also needs to be configured to enable OpenTelemetry data collection, with the URL of the collector.  This is a small [Helm configuration](manifests/howso-platform.yaml) that can be included with the other configuration for the Howso Platform.  Working from the [basic Helm installation](../helm-basic/README.md) this can be added in as additional Helm values
 
 ```sh
-helm upgrade --install install howso-platform \
+helm upgrade --install howso-platform \
   oci://registry.how.so/howso-platform/stable/howso-platform \
   --namespace howso \
   --values helm-basic/manifests/howso-platform.yaml \
+  --wait \
   --values opentelemetry/manifests/howso-platform.yaml  # <-- add to basic setup
 ```
 

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -1,0 +1,62 @@
+# OpenTelemetry
+
+## Prerequisites
+
+- [General prerequisites](../prereqs/README.md)
+- [Helm Online Installation for Howso Platform](../helm-basic/README.md)
+
+## Introduction
+
+[OpenTelemetry](https://opentelemetry.io) is a unified open-source observability tool.  It includes common code for collecting metrics, traces, and logs across a distributed system.
+
+To process telemetry data, the Howso Platform requires that the cluster be running an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).  Individual components of the system forward data to the collector, which in turn forwards it onwards to other observability tools.  An OpenTelemetry collector might forward traces to a [Jaeger](https://www.jaegertracing.io/) instance and metrics to [Prometheus](https://prometheus.io), for example.  So long as the collector is running, the Howso Platform is agnostic to the specific choice of observability backends.
+
+The Howso Platform does not require an OpenTelemetry collector for standard data processing and synthesis tasks.  It is only required to collect more detailed metrics about individual components' operation and to debug performance and scaling problems in the system.
+
+## Installing the Collector
+
+There are several ways to install the collector.  For this example, we will use the [OpenTelemetry Collector Chart](https://opentelemetry.io/docs/kubernetes/helm/collector/):
+
+```sh
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm install platform-opentelemetry-collector \
+  open-telemetry/opentelemetry-collector \
+  --namespace howso \
+  --values opentelemetry/manifests/opentelemetry-collector.yaml
+```
+
+This default configuration installs a collector, but does not necessarily send its output anywhere.  The chart can take [extended configuration options](https://opentelemetry.io/docs/kubernetes/helm/collector/#configuration) that tell it where to forward traces and metrics when it receives them.
+
+In the [Helm configuration](manifests/opentelemetry-collector.yaml) we enable the "contrib" version of the collector.  This includes a number of extended destinations and processing options.  We also configure the collector to inject Kubernetes-related metadata into traces and metrics as it receives them.  The collector has a number of other configuration settings, and different configurations may require it to be run as a Deployment (fixed number of cluster-wide collector instances) or as a DaemonSet (one collector on each cluster node).
+
+The Howso Platform also needs to be configured to enable OpenTelemetry data collection, with the URL of the collector.  This is a small [Helm configuration](manifests/howso-platform.yaml) that can be included with the other configuration for the Howso Platform.  Working from the [basic Helm installation](../helm-basic/README.md) this can be added in as additional Helm values
+
+```sh
+helm upgrade --install install howso-platform \
+  oci://registry.how.so/howso-platform/stable/howso-platform \
+  --namespace howso \
+  --values helm-basic/manifests/howso-platform.yaml \
+  --values opentelemetry/manifests/howso-platform.yaml  # <-- add to basic setup
+```
+
+These examples install a dedicated OpenTelemetry collector for the Howso Platform, in the same namespace.  So long as the configured collector URL is reachable from the Kubernetes Pods, the collector does not necessarily need to be in the same namespace or even in the cluster.
+
+This setup does not significantly configure the OpenTelemetry collector.  If you look at its output
+
+```sh
+kubectl logs --namespace howso deployment/platform-opentelemetry-collector
+```
+
+it outputs messages that it is receiving data, but these data are not processed or forwarded anywhere.
+
+## Further Configuration
+
+Your local environment may already contain core observability tools.  For example, the OpenTelemetry collector can forward metrics to a Prometheus push gateway.
+
+The [OpenTelemetry collector configuration](https://opentelemetry.io/docs/collector/configuration/) documentation describes the available configuration options.  All of the options shown in that documentation can be put under a `config:` key in the Helm values; the [end-to-end sample collector configuration](../opentelemetry-e2e/manifests/opentelemetry-collector.yaml) demonstrates this.
+
+The Howso Platform publishes all data to a gRPC endpoint on port 4317 in the collector.  This receiver must be enabled but others can be disabled if needed.
+
+## Extended Example
+
+[OpenTelemetry End-to-End Setup](../opentelemetry-e2e/README.md) contains an extended setup, installing Prometheus, Grafana, Jaeger, and the OpenTelemetry collector in a new cluster.

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-[OpenTelemetry](https://opentelemetry.io) is a unified open-source observability tool.  It includes common code for collecting metrics, traces, and logs across a distributed system.
+[OpenTelemetry](https://opentelemetry.io) is a unified open-source observability tool.  It includes common code for collecting metrics, traces, and logs across a distributed system.  Starting with release 2024.6.1, the Howso Platform can publish observability data to OpenTelemetry.
 
 To process telemetry data, the Howso Platform requires that the cluster be running an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/).  Individual components of the system forward data to the collector, which in turn forwards it onwards to other observability tools.  An OpenTelemetry collector might forward traces to a [Jaeger](https://www.jaegertracing.io/) instance and metrics to [Prometheus](https://prometheus.io), for example.  So long as the collector is running, the Howso Platform is agnostic to the specific choice of observability backends.
 
@@ -28,6 +28,8 @@ helm install platform-opentelemetry-collector \
 This default configuration installs a collector, but does not necessarily send its output anywhere.  The chart can take [extended configuration options](https://opentelemetry.io/docs/kubernetes/helm/collector/#configuration) that tell it where to forward traces and metrics when it receives them.
 
 In the [Helm configuration](manifests/opentelemetry-collector.yaml) we enable the "contrib" version of the collector.  This includes a number of extended destinations and processing options.  We also configure the collector to inject Kubernetes-related metadata into traces and metrics as it receives them.  The collector has a number of other configuration settings, and different configurations may require it to be run as a Deployment (fixed number of cluster-wide collector instances) or as a DaemonSet (one collector on each cluster node).
+
+The sample configuration uses the Kubernetes API to collect Kubernetes-related attributes that are attached to observability data.  This requires permissions to read Kubernetes Namespace, Pod, and ReplicaSet objects; also see the [collector's Kubernetes ClusterRole](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/templates/clusterrole.yaml).  The collector does not require additional permissions, unless it is configured to read broader Kubernetes metrics.  In the sample configuration, annotating data with `kubernetesAttributes:` can be disabled to avoid needing these permissions.
 
 The Howso Platform also needs to be configured to enable OpenTelemetry data collection, with the URL of the collector.  This is a small [Helm configuration](manifests/howso-platform.yaml) that can be included with the other configuration for the Howso Platform.  Working from the [basic Helm installation](../helm-basic/README.md) this can be added in as additional Helm values
 

--- a/opentelemetry/manifests/howso-platform.yaml
+++ b/opentelemetry/manifests/howso-platform.yaml
@@ -1,0 +1,3 @@
+opentelemetry:
+  enabled: true
+  url: http://platform-opentelemetry-collector:4317

--- a/opentelemetry/manifests/opentelemetry-collector.yaml
+++ b/opentelemetry/manifests/opentelemetry-collector.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: otel/opentelemetry-collector-contrib
+command:
+  name: otelcol-contrib
+mode: deployment
+presets:
+  kubernetesAttributes:
+    enabled: true


### PR DESCRIPTION
In two phases.  `opentelemetry` installs the OpenTelemetry collector and configures the Howso Platform to talk to it.  `opentelemetry-e2e` also installs kube-prometheus-stack and Jaeger for an end-to-end setup.